### PR TITLE
Allow writing to /sync folder

### DIFF
--- a/root/defaults/sync.conf
+++ b/root/defaults/sync.conf
@@ -11,6 +11,6 @@
     {
 	"listen" : "0.0.0.0:8888",
 	"allow_empty_password" : false,
-        "dir_whitelist" : [ "/sync/folders", "/sync/mounted_folders" ]
+        "dir_whitelist" : [ "/sync", "/sync/folders", "/sync/mounted_folders" ]
     }
 }


### PR DESCRIPTION
Even after setting the uid and gid to the default user id, it failed to allow writing to the folder from the web interface. Could not create new folders or add shares before. This is a fix for that.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

